### PR TITLE
Add Renovate config to enable the Automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>RightCapitalHQ/renovate-config"],
+  "assignees": ["thinkingjimmy"],
+  "reviewers": ["thinkingjimmy"],
+  "labels": ["dependencies"],
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "prCreation": "immediate",
+  "lockFileMaintenance": {
+    "automerge": true,
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "automerge": false,
+      "description": "Mark rule and plugin updates as breaking changes",
+      "matchDepTypes": ["dependencies"],
+      "matchPackagePrefixes": [
+        "@typescript-eslint/",
+        "eslint-config-",
+        "eslint-plugin-"
+      ]
+    },
+
+    {
+      "automerge": false,
+      "description": "Group all DevDependencies together",
+      "groupName": "DevDependencies",
+      "groupSlug": "auto-merge-dev-dependencies-updates",
+      "matchDepTypes": ["devDependencies"]
+    }
+  ]
+}


### PR DESCRIPTION
# 当前的问题

当前使用的很多软件的依赖没有自动升级，很快会outdated, 有潜在的安全风险。

# Renovate
我们可以使用 Renovate 来自动处理依赖的升级管理，通过配置一定的规则来实现自动升级
目前的规则是：
根据 [conventionalcommits](https://www.conventionalcommits.org/en/) 的定义，对于 
- Non-major Updates  也就是 minor, patch 或者 pin dependencies 级别的修改，自动升级并merge
- Major Updates， 也就是 major 包的修改，则会创建PR 人工 review.

# 需要如何操作
1. Merge 此 PR
2. 需要添加 Renovate Bot 到仓库 -> https://github.com/apps/renovate  ,Grant 合适的访问此仓库的权限
之后 RenovateBot 会根据 `<root>/renovate.json` 的定义进行自动依赖管理
