### PR TITLE
Support Dark mode for announcement bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,8 +73,8 @@ const config = {
       announcementBar: {
         content:
           '⭐ If you have any questions, feel free to join our <a target="_blank" href="https://discord.gg/B7Z7wjuUPg">Discord</a>.⭐',
-        backgroundColor: '#fafbfc',
-        textColor: '#091E42',
+        backgroundColor: 'var(--announcement-bar-background-color)',
+        textColor: 'var(--announcement-bar-text-color)',
         isCloseable: false,
       },
       navbar: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -259,6 +259,10 @@ body {
   --docusaurus-highlighted-code-line-bg: rgba(147, 178, 244, 0.38);
 
   --font-ui: var(--ifm-font-family-base) !important;
+
+  /* Colors for announcement bar */
+  --announcement-bar-background-color: #fafbfc;
+  --announcement-bar-text-color: #091E42;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -277,6 +281,10 @@ html[data-theme='dark'] {
   --ifm-color-content: #e7e7e7;
 
   --docusaurus-highlighted-code-line-bg: rgba(105, 105, 105, 0.3);
+
+  /* Colors for announcement bar on dark mode */
+  --announcement-bar-background-color: #091E42;
+  --announcement-bar-text-color: #fafbfc;
 }
 
 nav.navbar {
@@ -1079,3 +1087,4 @@ img[src$='#terminal'] {
   border-top-style: solid;
   border-top-width: 1px;
 }
+


### PR DESCRIPTION
# The dark mode for announcement bar
It was a little weird when I switched to dark mode without the announcement bar updated. 

so I just added the ability for that part to be updatable for the mode-switching

Here is the final effect of this part in dark mode

<img width="1009" alt="image" src="https://github.com/thinkingjimmy/Learning-Prompt/assets/101971/2458327b-1240-4d4f-8412-46331149a73d">

The light mode didn't update so it works as it was 

Let me know if the color is not good. I will update it. 